### PR TITLE
Fix multi-definition error resulting from NullType::header

### DIFF
--- a/include/message_filters/null_types.h
+++ b/include/message_filters/null_types.h
@@ -54,8 +54,6 @@ struct NullType
   static MsgHeader header;
 };
 
-MsgHeader NullType::header = {rclcpp::Time()};
-
 typedef std::shared_ptr<NullType const> NullTypeConstPtr;
 template<class M>
 struct NullFilter


### PR DESCRIPTION
The direct definition to NullType::header in the header file
will leads multi-definition error while including from different
binary objects.

Signed-off-by: gaoethan <gaoethan>