### PR TITLE
Adding missing dependencies to package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if(BUILD_TESTING)
     target_link_libraries(${PROJECT_NAME}-test_exact_time_policy ${PROJECT_NAME})
   endif()
 
-  ament_add_gtest(${PROJECT_NAME}-test_approximate_time_policy test/test_approximate_time_policy.cpp)
+  #ament_add_gtest(${PROJECT_NAME}-test_approximate_time_policy test/test_approximate_time_policy.cpp)
   if(TARGET ${PROJECT_NAME}-test_approximate_time_policy)
     target_link_libraries(${PROJECT_NAME}-test_approximate_time_policy ${PROJECT_NAME})
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if(BUILD_TESTING)
     target_link_libraries(${PROJECT_NAME}-test_exact_time_policy ${PROJECT_NAME})
   endif()
 
-  #ament_add_gtest(${PROJECT_NAME}-test_approximate_time_policy test/test_approximate_time_policy.cpp)
+  ament_add_gtest(${PROJECT_NAME}-test_approximate_time_policy test/test_approximate_time_policy.cpp)
   if(TARGET ${PROJECT_NAME}-test_approximate_time_policy)
     target_link_libraries(${PROJECT_NAME}-test_approximate_time_policy ${PROJECT_NAME})
   endif()

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,10 @@
   <build_depend>rcutils</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>ament_lint_auto</build_depend>
+  <build_depend>ament_cmake_gtest</build_depend>
+  <build_depend>ament_cmake_pytest</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rcutils</exec_depend>


### PR DESCRIPTION
I tried building the repo as part of the overall ros workspace
using colcon. That revealed a few missing dependencies from
package.xml, some of which are only exposed because colcon builds
with BUILD_TESTING enabled by default.