### PR TITLE
Fixed error: FrameId is not a member of message_filters::message_traits

### DIFF
--- a/include/message_filters/message_traits.h
+++ b/include/message_filters/message_traits.h
@@ -45,6 +45,25 @@ template <typename M>
 struct HasHeader<M, decltype((void) M::header)> : std::true_type {};
 
 /**
+ * \brief FrameId trait.  In the default implementation pointer()
+ * returns &m.header.frame_id if HasHeader<M>::value is true, otherwise returns NULL.  value()
+ * does not exist, and causes a compile error
+ */
+template<typename M, typename Enable = void>
+struct FrameId
+{
+  static std::string* pointer(M& m) { (void)m; return nullptr; }
+  static std::string const* pointer(const M& m) { (void)m; return nullptr; }
+};
+ template<typename M>
+struct FrameId<M, typename std::enable_if<HasHeader<M>::value>::type >
+{
+  static std::string* pointer(M& m) { return &m.header.frame_id; }
+  static std::string const* pointer(const M& m) { return &m.header.frame_id; }
+  static std::string value(const M& m) { return m.header.frame_id; }
+};
+
+/**
  * \brief TimeStamp trait.  In the default implementation pointer()
  * returns &m.header.stamp if HasHeader<M>::value is true, otherwise returns NULL.  value()
  * does not exist, and causes a compile error


### PR DESCRIPTION
While using message_filters packge in laser_assembler porting to ROS2, got following error,
‘FrameId’ is not a member of ‘mt’
     std::string frame_id = stripSlash(mt::FrameId<M>::value(*message));
where mt is of type message_filters::message_traits;
So fixed it by adding FrameId support in message_traits.h file of message_filters package.

